### PR TITLE
Check existence before deleting old key from cache

### DIFF
--- a/sap_rpt_oss/utils/lru_cache.py
+++ b/sap_rpt_oss/utils/lru_cache.py
@@ -54,7 +54,8 @@ class LRU_Cache:
             oldresult = self.root[self.RESULT]
             self.root[self.KEY] = self.root[self.RESULT] = None
             # Now update the cache dictionary.
-            del self.cache[oldkey]
+            if oldkey in self.cache:
+                del self.cache[oldkey]
             # Save the potentially reentrant cache[key] assignment
             # for last, after the root and links have been put in
             # a consistent state.


### PR DESCRIPTION
Heyho, 

The LRU cache tries to delete a `None` entry from the cache that does not exist and thus crashes. 

I don't know why this happens, but it does on TabArena a few times (e.g. on this dataset https://www.kaggle.com/competitions/amazon-employee-access-challenge/data?select=train.csv). 
The PR fixes it for me. 

Could it be because the code treats high-cardinal categoricals as text? 


